### PR TITLE
(fix) Reformat "No argument provided..." message

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
 	elif "-a" in sys.argv:
 		print(decode(input()))
 	elif len(sys.argv) < 1:
-		print("No argument provided. Try `-g` or -`a`.")
+		print("No argument provided. Try `-g' or `-a'.")
 	else:
 		print("Invalid arguments.")
 


### PR DESCRIPTION
Proper formatting and mirroring the message from xnil/GGg verbatim.
